### PR TITLE
Capture request header metadata in access log

### DIFF
--- a/files/bluebutton-appserver-config.sh
+++ b/files/bluebutton-appserver-config.sh
@@ -266,7 +266,7 @@ end-if
 if (outcome == success) of /subsystem=undertow/server=default-server/host=default-host/setting=access-log:read-resource
 	/subsystem=undertow/server=default-server/host=default-host/setting=access-log:remove
 end-if
-/subsystem=undertow/server=default-server/host=default-host/setting=access-log:add(pattern="%h %l %u %t \\"%r\\" \\"?%q\\" %s %B %D", directory="\${jboss.server.log.dir}", prefix="access", suffix=".log")
+/subsystem=undertow/server=default-server/host=default-host/setting=access-log:add(pattern="%h %l %u %t \\"%r\\" \\"?%q\\" %s %B %D %{i,BlueButton-OriginalQueryId} %{i,BlueButton-OriginalQueryCounter} %{i,BlueButton-OriginalQueryTimestamp} %{i,BlueButton-DeveloperId} %{i,BlueButton-Developer} %{i,BlueButton-ApplicationId} %{i,BlueButton-Application} %{i,BlueButton-UserId} %{i,BlueButton-User} %{i,BlueButton-BeneficiaryId}", directory="\${jboss.server.log.dir}", prefix="access", suffix=".log")
 
 # Reload the server to apply those changes.
 :reload


### PR DESCRIPTION
Per CBBP-603, the frontend will now set all of these fields in each request that it issues. We want to capture them to ensure that our logs can be correlated with frontend activity, which will allow us to answer questions like:

* Why is anyone running this request?
* Which devs/apps/benes are responsible for most of the requests hitting the backend?

... and such.

https://issues.hhsdevcloud.us/browse/CBBF-103