### PR TITLE
CBBF-103: Quoted/bracketed fields that might have spaces

### DIFF
--- a/files/bluebutton-appserver-config.sh
+++ b/files/bluebutton-appserver-config.sh
@@ -266,7 +266,7 @@ end-if
 if (outcome == success) of /subsystem=undertow/server=default-server/host=default-host/setting=access-log:read-resource
 	/subsystem=undertow/server=default-server/host=default-host/setting=access-log:remove
 end-if
-/subsystem=undertow/server=default-server/host=default-host/setting=access-log:add(pattern="%h %l %u %t \\"%r\\" \\"?%q\\" %s %B %D %{i,BlueButton-OriginalQueryId} %{i,BlueButton-OriginalQueryCounter} %{i,BlueButton-OriginalQueryTimestamp} %{i,BlueButton-DeveloperId} %{i,BlueButton-Developer} %{i,BlueButton-ApplicationId} %{i,BlueButton-Application} %{i,BlueButton-UserId} %{i,BlueButton-User} %{i,BlueButton-BeneficiaryId}", directory="\${jboss.server.log.dir}", prefix="access", suffix=".log")
+/subsystem=undertow/server=default-server/host=default-host/setting=access-log:add(pattern="%h %l %u %t \\"%r\\" \\"?%q\\" %s %B %D %{i,BlueButton-OriginalQueryId} %{i,BlueButton-OriginalQueryCounter} [%{i,BlueButton-OriginalQueryTimestamp}] %{i,BlueButton-DeveloperId} \\"%{i,BlueButton-Developer}\\" %{i,BlueButton-ApplicationId} \\"%{i,BlueButton-Application}\\" %{i,BlueButton-UserId} \\"%{i,BlueButton-User}\\" %{i,BlueButton-BeneficiaryId}", directory="\${jboss.server.log.dir}", prefix="access", suffix=".log")
 
 # Reload the server to apply those changes.
 :reload


### PR DESCRIPTION
Previous format was impossible to correctly parse, due to lack of clear field boundaries. We could still be in trouble if we get values with quotes in them, but that's a low-probability thing with a very high cost
to fix (Wildfly doesn't provide any great facilities for handling it, so it'd be a lot of extension code).

CBBF-103