### PR TITLE
Have service wait for network before starting.

### DIFF
--- a/templates/bluebutton-appserver.service.j2
+++ b/templates/bluebutton-appserver.service.j2
@@ -1,5 +1,7 @@
 [Unit]
 Description=Blue Button Data Server
+Wants=network-online.target
+After=network.target network-online.target
 
 [Service]
 WorkingDirectory={{ data_server_dir }}


### PR DESCRIPTION
I haven't seen this cause problems yet, but it was causing the Data Pipeline service to go boom after system restarts, so it seems like a good idea to do here, too.

https://issues.hhsdevcloud.us/browse/CBBD-402