### PR TITLE
BLUEBUTTON-945: Add security domain for the Data Server

### DIFF
--- a/files/bluebutton-appserver-config.sh
+++ b/files/bluebutton-appserver-config.sh
@@ -268,6 +268,14 @@ if (outcome == success) of /subsystem=undertow/server=default-server/host=defaul
 end-if
 /subsystem=undertow/server=default-server/host=default-host/setting=access-log:add(pattern="%h %l %u %t \\"%r\\" \\"?%q\\" %s %B %D %{i,BlueButton-OriginalQueryId} %{i,BlueButton-OriginalQueryCounter} [%{i,BlueButton-OriginalQueryTimestamp}] %{i,BlueButton-DeveloperId} \\"%{i,BlueButton-Developer}\\" %{i,BlueButton-ApplicationId} \\"%{i,BlueButton-Application}\\" %{i,BlueButton-UserId} \\"%{i,BlueButton-User}\\" %{i,BlueButton-BeneficiaryId}", directory="\${jboss.server.log.dir}", prefix="access", suffix=".log")
 
+# Configure the application's security domain.
+if (outcome == success) of /subsystem=security/security-domain=bluebutton-data-server:read-resource
+	/subsystem=security/security-domain=bluebutton-data-server:remove
+end-if
+/subsystem=security/security-domain=bluebutton-data-server:add(cache-type="default")
+/subsystem=security/security-domain=bluebutton-data-server/authentication=classic:add(login-modules=[{"code"=>"CertificateRoles","flag"=>"required","module-options"=>[("securityDomain"=>"bluebutton-data-server"),("verifier"=>"org.jboss.security.auth.certs.AnyCertVerifier"),("rolesProperties"=>"file:\${bbfhir.roles}")]}])
+/subsystem=security/security-domain=bluebutton-data-server/jsse=classic:add(truststore={password="changeit",url="file:${trustStore}"},keystore={password="changeit",url="file:${keyStore}"},client-auth=true)
+
 # Reload the server to apply those changes.
 :reload
 EOF

--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -109,6 +109,15 @@
     mode: u=rw,g=rw,o=r
   become: true
 
+- name: Configure App Server Roles
+  template:
+    src: 'templates/server-roles.properties.j2'
+    dest: "{{ data_server_dir }}/bluebutton-appserver-roles.properties"
+    owner: "{{ data_server_user }}"
+    group: "{{ data_server_user }}"
+    mode: u=rw,g=rw,o=r
+  become: true
+
 # Need to ensure service is running (and has been restarted if needed) before config, as it needs the server to be available.
 - meta: flush_handlers
 

--- a/templates/server-roles.properties.j2
+++ b/templates/server-roles.properties.j2
@@ -1,0 +1,2 @@
+# We don't yet have or use roles, but this file is still required by the
+# Wildfly/JBoss `<security-domain name="bluebutton-data-server" />`.


### PR DESCRIPTION
There's a couple of PRs brewing in the Data Server repo that will require this security domain to be present.

This change here _should_ be backwards compatible: it should work before the corresponding Data Server changes are deployed. (I'll need to verify that in a test environment, though.)

https://jira.cms.gov/browse/BLUEBUTTON-945