### PR TITLE
BLUEBUTTON-1057: Restart JBoss, rather than calling :reload

### DIFF
--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -131,7 +131,7 @@
   become: true
 
 - name: Run App Server Config Script
-  command: "{{ data_server_dir }}/bluebutton-appserver-config.sh --serverhome {{ data_server_dir }}/{{ data_server_appserver_name }} --managementport {{ data_server_appserver_management_port }} --managementusername \"{{ data_server_appserver_management_username }}\" --managementpassword \"{{ data_server_appserver_management_password }}\" --httpsport {{ data_server_appserver_https_port }} --keystore {{ data_server_dir }}/bluebutton-appserver-keystore.jks --truststore {{ data_server_dir }}/bluebutton-appserver-truststore.jks --dburl {{ data_server_db_url }} --dbusername {{ data_server_db_username }} --dbpassword {{ data_server_db_password }} --dbconnectionsmax {{ data_server_db_max_connections }} --rolesprops {{ data_server_dir }}/bluebutton-appserver-roles.properties"
+  command: "{{ data_server_dir }}/bluebutton-appserver-config.sh --serverhome {{ data_server_dir }}/{{ data_server_appserver_name }} --servicename {{ data_server_appserver_service }} --managementport {{ data_server_appserver_management_port }} --managementusername \"{{ data_server_appserver_management_username }}\" --managementpassword \"{{ data_server_appserver_management_password }}\" --httpsport {{ data_server_appserver_https_port }} --keystore {{ data_server_dir }}/bluebutton-appserver-keystore.jks --truststore {{ data_server_dir }}/bluebutton-appserver-truststore.jks --dburl {{ data_server_db_url }} --dbusername {{ data_server_db_username }} --dbpassword {{ data_server_db_password }} --dbconnectionsmax {{ data_server_db_max_connections }} --rolesprops {{ data_server_dir }}/bluebutton-appserver-roles.properties"
   changed_when: true
   become: true
   become_user: "{{ data_server_user }}"


### PR DESCRIPTION
I think the issue causing this intermittent bug is the use of `:reload` inside an `if ... end-if` block. But that's just a guess, so the safest thing to do is always restart the whole service, rather than reload.

I also decided to go from three config blocks to just two, which should make the extra delay from a full restart slightly less painful.

https://jira.cms.gov/browse/BLUEBUTTON-1057