### PR TITLE
BLUEBUTTON-1057: Fixed dumb typo: missing equals sign

### DIFF
--- a/files/bluebutton-appserver-config.sh
+++ b/files/bluebutton-appserver-config.sh
@@ -45,7 +45,7 @@ while true; do
 		-h | --serverhome )
 			serverHome="$2"; shift 2 ;;
 		-d | --servicename )
-			serviceName"$2"; shift 2 ;;
+			serviceName="$2"; shift 2 ;;
 		-m | --managementport )
 			managementPort="$2"; shift 2 ;;
 		-U | --managementusername )


### PR DESCRIPTION
I hate this whole workflow: no way to test things until they've been merged.

I swear I checked this line by eye at least three times (because I was worried about typos and copy-paste errors like this) and **still** missed my mistake.

https://jira.cms.gov/browse/BLUEBUTTON-1057