### PR TITLE
BLUEBUTTON-1057: Ensure appserver service is running before config

### DIFF
--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -118,6 +118,12 @@
     mode: u=rw,g=rw,o=r
   become: true
 
+- name: Start App Server Service
+  service:
+    name: "{{ data_server_appserver_service }}"
+    state: started
+  become: true
+
 # Need to ensure service is running (and has been restarted if needed) before config, as it needs the server to be available.
 - meta: flush_handlers
 


### PR DESCRIPTION
I'm surprised this hasn't been noticed before, but: if someone manually stops the app server service, or if it crashes completely, then the next deploy will fail (unless someone manually restarts it first).

This fixes that.

https://jira.cms.gov/browse/BLUEBUTTON-1057