### PR TITLE
BLUEBUTTON-1057: Use :reload instead of service restart

### DIFF
--- a/files/bluebutton-appserver-config.sh
+++ b/files/bluebutton-appserver-config.sh
@@ -145,6 +145,8 @@ waitForServerReady
 # Notes:
 # * This interesting use of heredocs is documented here: <http://unix.stackexchange.com/a/168434>.
 # * The `:reload` CLI command must be called after (some) config changes.
+#     * It must be the last command in a config script, and
+#       `waitForServerReady` must be called right afterwards.
 #     * It may not be called from within an `if ... end-if` block, or any other
 #       block, as this will cause intermittent race condition errors.
 #     * A service restart may not be substituted for it, as that may cause
@@ -180,6 +182,8 @@ waitForServerReady
 # Notes:
 # * This interesting use of heredocs is documented here: <http://unix.stackexchange.com/a/168434>.
 # * The `:reload` CLI command must be called after (some) config changes.
+#     * It must be the last command in a config script, and
+#       `waitForServerReady` must be called right afterwards.
 #     * It may not be called from within an `if ... end-if` block, or any other
 #       block, as this will cause intermittent race condition errors.
 #     * A service restart may not be substituted for it, as that may cause

--- a/files/bluebutton-appserver-config.sh
+++ b/files/bluebutton-appserver-config.sh
@@ -18,8 +18,8 @@ scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Use GNU getopt to parse the options passed to this script.
 TEMP=`getopt \
-	-o h:d:m:U:P:s:k:t:u:n:p:c:r: \
-	--long serverhome:,servicename:,managementport:,managementusername:,managementpassword:,httpsport:,keystore:,truststore:,dburl:,dbusername:,dbpassword:,dbconnectionsmax:,rolesprops: \
+	-o h:m:U:P:s:k:t:u:n:p:c:r: \
+	--long serverhome:,managementport:,managementusername:,managementpassword:,httpsport:,keystore:,truststore:,dburl:,dbusername:,dbpassword:,dbconnectionsmax:,rolesprops: \
 	-n 'bluebutton-appserver-config.sh' -- "$@"`
 if [ $? != 0 ] ; then echo "Terminating." >&2 ; exit 1 ; fi
 
@@ -28,7 +28,6 @@ eval set -- "$TEMP"
 
 # Parse the getopt results.
 serverHome=
-serviceName=
 managementPort=9990
 managementUsername=
 managementPassword=
@@ -44,8 +43,6 @@ while true; do
 	case "$1" in
 		-h | --serverhome )
 			serverHome="$2"; shift 2 ;;
-		-d | --servicename )
-			serviceName="$2"; shift 2 ;;
 		-m | --managementport )
 			managementPort="$2"; shift 2 ;;
 		-U | --managementusername )
@@ -75,7 +72,6 @@ done
 
 # Verify that all required options were specified.
 if [[ -z "${serverHome}" ]]; then >&2 echo 'The --serverhome option is required.'; exit 1; fi
-if [[ -z "${serviceName}" ]]; then echo 'The --servicename option is required.' |& tee --append "${serverHome}/server-config.log"; exit 1; fi
 if [[ -z "${httpsPort}" ]]; then echo 'The --httpsport option is required.' |& tee --append "${serverHome}/server-config.log"; exit 1; fi
 if [[ -z "${keyStore}" ]]; then echo 'The --keystore option is required.' |& tee --append "${serverHome}/server-config.log"; exit 1; fi
 if [[ -z "${trustStore}" ]]; then echo 'The --truststore option is required.' |& tee --append "${serverHome}/server-config.log"; exit 1; fi
@@ -137,22 +133,23 @@ waitForServerReady() {
 	done
 }
 
-# Define a function that can reload/restart the service and then wait for it to be ready.
-reloadServerAndWaitForReady() {
-	echo "Restarting '${serviceName}' service..." |& tee --append "${serverHome}/server-config.log"
-	systemctl restart "${serviceName}"
-	echo "Restarted '${serviceName}' service." |& tee --append "${serverHome}/server-config.log"
-	waitForServerReady
-}
-
 # Wait for the server to be ready, in case this script is being called right
 # after the server is started/restarted.
 waitForServerReady
 
 # Use the Wildfly CLI to configure the server.
+#
 # These have to be run first as until they're done and the server has reloaded,
 # parts of the next big chunk of config may fail.
-# (Note: This interesting use of heredocs is documented here: http://unix.stackexchange.com/a/168434)
+#
+# Notes:
+# * This interesting use of heredocs is documented here: <http://unix.stackexchange.com/a/168434>.
+# * The `:reload` CLI command must be called after (some) config changes.
+#     * It may not be called from within an `if ... end-if` block, or any other
+#       block, as this will cause intermittent race condition errors.
+#     * A service restart may not be substituted for it, as that may cause
+#       different race condition errors where the server fails some of the
+#       config changes.
 echo "Configuring server (enabling HTTPS and creating security domain)..." |& tee --append "${serverHome}/server-config.log"
 cat <<EOF |
 # Enable HTTPS.
@@ -164,6 +161,9 @@ end-if
 if (outcome == success) of /subsystem=security/security-domain=bluebutton-data-server:read-resource
 	/subsystem=security/security-domain=bluebutton-data-server:remove
 end-if
+
+# Reload the server to apply those changes.
+:reload
 EOF
 "${serverHome}/bin/jboss-cli.sh" \
 	--controller=localhost:${managementPort} \
@@ -173,10 +173,18 @@ EOF
 	--file=/dev/stdin \
 	&>> "${serverHome}/server-config.log"
 echo "Server configured successfully (enabled HTTPS and created security domain)." |& tee --append "${serverHome}/server-config.log"
-reloadServerAndWaitForReady
+waitForServerReady
 
 # Use the Wildfly CLI to configure the server.
-# (Note: This interesting use of heredocs is documented here: http://unix.stackexchange.com/a/168434)
+#
+# Notes:
+# * This interesting use of heredocs is documented here: <http://unix.stackexchange.com/a/168434>.
+# * The `:reload` CLI command must be called after (some) config changes.
+#     * It may not be called from within an `if ... end-if` block, or any other
+#       block, as this will cause intermittent race condition errors.
+#     * A service restart may not be substituted for it, as that may cause
+#       different race condition errors where the server fails some of the
+#       config changes.
 echo "Configuring server (everything else)..." |& tee --append "${serverHome}/server-config.log"
 cat <<EOF |
 # Set applications to use SLF4J for the logging, rather than JBoss' builtin 
@@ -290,6 +298,9 @@ end-if
 /subsystem=security/security-domain=bluebutton-data-server:add(cache-type="default")
 /subsystem=security/security-domain=bluebutton-data-server/authentication=classic:add(login-modules=[{"code"=>"CertificateRoles","flag"=>"required","module-options"=>[("securityDomain"=>"bluebutton-data-server"),("verifier"=>"org.jboss.security.auth.certs.AnyCertVerifier"),("rolesProperties"=>"file:${rolesPropertiesPath}")]}])
 /subsystem=security/security-domain=bluebutton-data-server/jsse=classic:add(truststore={password="changeit",url="file:${trustStore}"},keystore={password="changeit",url="file:${keyStore}"},client-auth=true)
+
+# Reload the server to apply those changes.
+:reload
 EOF
 "${serverHome}/bin/jboss-cli.sh" \
 	--controller=localhost:${managementPort} \
@@ -299,4 +310,4 @@ EOF
 	--file=/dev/stdin \
 	&>> "${serverHome}/server-config.log"
 echo "Server configured successfully." |& tee --append "${serverHome}/server-config.log"
-reloadServerAndWaitForReady
+waitForServerReady

--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -30,7 +30,7 @@
   become_user: "{{ data_server_user }}"
   no_log: true  # Ensure that the key args aren't logged if this command fails.
 
-# TODO: Export server's public cert and publish to S3 or somesuch (s0 the frontend and others can pick it up).
+# TODO: Export server's public cert and publish to S3 or somesuch (so the frontend and others can pick it up).
 
 - name: Secure App Server SSL Keystore
   file:

--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -131,7 +131,7 @@
   become: true
 
 - name: Run App Server Config Script
-  command: "{{ data_server_dir }}/bluebutton-appserver-config.sh --serverhome {{ data_server_dir }}/{{ data_server_appserver_name }} --servicename {{ data_server_appserver_service }} --managementport {{ data_server_appserver_management_port }} --managementusername \"{{ data_server_appserver_management_username }}\" --managementpassword \"{{ data_server_appserver_management_password }}\" --httpsport {{ data_server_appserver_https_port }} --keystore {{ data_server_dir }}/bluebutton-appserver-keystore.jks --truststore {{ data_server_dir }}/bluebutton-appserver-truststore.jks --dburl {{ data_server_db_url }} --dbusername {{ data_server_db_username }} --dbpassword {{ data_server_db_password }} --dbconnectionsmax {{ data_server_db_max_connections }} --rolesprops {{ data_server_dir }}/bluebutton-appserver-roles.properties"
+  command: "{{ data_server_dir }}/bluebutton-appserver-config.sh --serverhome {{ data_server_dir }}/{{ data_server_appserver_name }} --managementport {{ data_server_appserver_management_port }} --managementusername \"{{ data_server_appserver_management_username }}\" --managementpassword \"{{ data_server_appserver_management_password }}\" --httpsport {{ data_server_appserver_https_port }} --keystore {{ data_server_dir }}/bluebutton-appserver-keystore.jks --truststore {{ data_server_dir }}/bluebutton-appserver-truststore.jks --dburl {{ data_server_db_url }} --dbusername {{ data_server_db_username }} --dbpassword {{ data_server_db_password }} --dbconnectionsmax {{ data_server_db_max_connections }} --rolesprops {{ data_server_dir }}/bluebutton-appserver-roles.properties"
   changed_when: true
   become: true
   become_user: "{{ data_server_user }}"


### PR DESCRIPTION
My previous commits/PRs just didn't pan out: restarting the service right after config changes led to _different_ race condition errors with JBoss.

We'll see, but I suspect this method here is the way to do it: use `:reload`, but ensure it's the last thing in the script; it can't even be inside a block at the end of the script.

But I'm fully prepared to find out I'm wrong here, too. JBoss is just full of surprises like that.

Note: The build here will fail, as it's broken for the entire project.

https://jira.cms.gov/browse/BLUEBUTTON-1057