### PR TITLE
BLUEBUTTON-1058: Restart JBoss on every deploy

### DIFF
--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -118,10 +118,11 @@
     mode: u=rw,g=rw,o=r
   become: true
 
-- name: Start App Server Service
+# Note: We always REstart here, because JBoss occassionally needs it. See BLUEBUTTON-1110 for an example.
+- name: Retart App Server Service
   service:
     name: "{{ data_server_appserver_service }}"
-    state: started
+    state: restarted
   become: true
 
 # Need to ensure service is running (and has been restarted if needed) before config, as it needs the server to be available.


### PR DESCRIPTION
As mentioned in the comment there, this seems to be necessary to get JBoss to release DB connections that it's holding on to.

https://jira.cms.gov/browse/BLUEBUTTON-1058