### PR TITLE
BLUEBUTTON-1133: Fix call to wait script

### DIFF
--- a/handlers/restart_appserver.yml
+++ b/handlers/restart_appserver.yml
@@ -13,7 +13,7 @@
   become: true
 
 - name: Wait for App Server to Be Ready
-  script: files/bluebutton-appserver-wait.sh
+  script: "files/bluebutton-appserver-wait.sh --serverhome {{ data_server_dir }}/{{ data_server_appserver_name }} --managementport {{ data_server_appserver_management_port }} --managementusername \"{{ data_server_appserver_management_username }}\" --managementpassword \"{{ data_server_appserver_management_password }}\""
   become: true
   become_user: "{{ data_server_user }}"
 

--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -8,8 +8,6 @@
     group: "{{ data_server_user }}"
     mode: u=rwx,g=rx,o=rx
   become: true
-  notify:
-    - Restart App Server Service
 
 # The AWS dev/test/prod environments aren't idempotent: the same base image 
 # will be reused and just upgraded over time. accordingly, we have to assume 
@@ -126,7 +124,7 @@
   become: true
 
 - name: Wait for App Server to Be Ready
-  script: files/bluebutton-appserver-wait.sh
+  script: "files/bluebutton-appserver-wait.sh --serverhome {{ data_server_dir }}/{{ data_server_appserver_name }} --managementport {{ data_server_appserver_management_port }} --managementusername \"{{ data_server_appserver_management_username }}\" --managementpassword \"{{ data_server_appserver_management_password }}\""
   become: true
   become_user: "{{ data_server_user }}"
 


### PR DESCRIPTION
Looks like this was broken in the handler that I copy-pasted it from, so I fixed it there, as well.

Also removed the unnecessary "notify" from the config tasks, as it would result in wasteful double restarts in some circumstances.

https://jira.cms.gov/browse/BLUEBUTTON-1133