### PR TITLE
BLUEBUTTON-1135: Increase File Descriptor limits

### DIFF
--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -147,3 +147,16 @@
   become_user: "{{ data_server_user }}"
   no_log: true  # Ensure passwords aren't logged if this fails.
 
+- name: Increase system-wide file descriptor (FD) limits
+  lineinfile:
+    path: /etc/sysctl.conf
+    line: fs.file-max=500000
+  become: true
+  
+- name: Increase user level soft/hard FD limits
+  blockinfile:
+    path: /etc/security/limits.conf
+    block: |
+          '*     soft nofile 500000'
+          '*     hard nofile 500000'
+  become: true

--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -146,17 +146,11 @@
   become: true
   become_user: "{{ data_server_user }}"
   no_log: true  # Ensure passwords aren't logged if this fails.
-
-- name: Increase system-wide file descriptor (FD) limits
-  lineinfile:
-    path: /etc/sysctl.conf
-    line: fs.file-max=500000
-  become: true
   
 - name: Increase user level soft/hard FD limits
   blockinfile:
     path: /etc/security/limits.conf
     block: |
-          '*     soft nofile 500000'
-          '*     hard nofile 500000'
+          '*     soft nofile 999999'
+          '*     hard nofile 999999'
   become: true

--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -153,5 +153,5 @@
     insertbefore: '# End of file'
     block: |
       {{ data_server_user }}     soft nofile 999999
-          '*     hard nofile 999999'
+      {{ data_server_user }}     hard nofile 999999
   become: true

--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -152,6 +152,6 @@
     path: /etc/security/limits.conf
     insertbefore: '# End of file'
     block: |
-          '*     soft nofile 999999'
+      {{ data_server_user }}     soft nofile 999999
           '*     hard nofile 999999'
   become: true

--- a/tasks/appserver_config.yml
+++ b/tasks/appserver_config.yml
@@ -150,6 +150,7 @@
 - name: Increase user level soft/hard FD limits
   blockinfile:
     path: /etc/security/limits.conf
+    insertbefore: '# End of file'
     block: |
           '*     soft nofile 999999'
           '*     hard nofile 999999'


### PR DESCRIPTION
Adding two new Ansible tasks to increase system wide and user level FD
limits to resolve an error where too many files are open at one time.

BLUEBUTTON-1135